### PR TITLE
Fix connection to SQL Server Named Instance

### DIFF
--- a/SolidQ.ABI.Compiler/infrastructure/Extensions.cs
+++ b/SolidQ.ABI.Compiler/infrastructure/Extensions.cs
@@ -58,7 +58,7 @@ namespace SolidQ.ABI.Compiler.Infrastructure
                 {
                     Expression = m.Groups["expression"].Value,
                     Name = m.Groups["name"].Value,
-                    Arguments = m.Groups["arguments"].Value
+                    Arguments = Regex.Unescape(m.Groups["arguments"].Value)
                         .Split(',') // do not use StringSplitOptions.RemoveEmptyEntries
                         .Select((a) => a.Trim(new[] { ' ', '\'' }))
                         .ToArray()


### PR DESCRIPTION
See issue #3 in ABI-Solution - connection to SQL Server Named Instance

The problem is that first we have to escape the backslash to have a valid JSON ("localhost\instance") and the compiler then escapes both of these backslashes ("localhost\\instance") so the resulting connection string is also "localhost\instance".

There is a workaround to Unescape string with arguments in the method ResolvePluginExpressions.

But this fix fails the following test: ResolvePluginExpressionsPreserveEscapeOnFilePath
I've left it like this so that you can decide if this fix is appropriate considering some other use cases. For now it works well with connection to our SQL Server Named Instance.
